### PR TITLE
Fix watchOS minimum platform version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
     platforms: [
         .macOS("10.15"),
         .iOS("13.0"),
-        .tvOS("13.0")
+        .tvOS("13.0"),
+        .watchOS("7.1")
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
When integrating `analytics-swift-consent` into a project that supports watchOS, you may encounter the following error:

> The package product `Segment` requires minimum platform version 7.1 for the watchOS platform, but this target supports 6.0.

This occurs because the `Segment` package sets its minimum watchOS version to 7.1 in its `Package.swift` file, while the `analytics-swift-consent` plugin does not specify a minimum version, defaulting to watchOS 6.0 as per Apple’s documentation:

> By default, the Swift Package Manager assigns a predefined minimum deployment version for each supported platform unless you configure supported platforms using the platforms API. This predefined deployment version is the oldest deployment target version that the installed SDK supports for a given platform.

To resolve this error, ensure that both packages specify the same minimum watchOS version (7.1) in their `Package.swift` files. This will align the platform requirements and fix the integration issue.