### PR TITLE
Fix retain cycles

### DIFF
--- a/Sources/SegmentConsent/Blocker.swift
+++ b/Sources/SegmentConsent/Blocker.swift
@@ -14,7 +14,7 @@ public class ConsentBlocker: EventPlugin {
     internal let store: Store
     
     public var type: PluginType = .before
-    public var analytics: Segment.Analytics?
+    public weak var analytics: Segment.Analytics?
     
     public init(destinationKey: String, store: Store) {
         self.destinationKey = destinationKey

--- a/Sources/SegmentConsent/Manager.swift
+++ b/Sources/SegmentConsent/Manager.swift
@@ -11,7 +11,7 @@ import Sovran
 
 public class ConsentManager: EventPlugin {
     public let type: PluginType = .before
-    public var analytics: Analytics? = nil
+    public weak var analytics: Analytics? = nil
     public let store = Store()
     
     internal var provider: ConsentCategoryProvider
@@ -23,7 +23,10 @@ public class ConsentManager: EventPlugin {
         self.provider = provider
         self.consentChange = consentChanged
         
-        self.provider.setChangeCallback(notifyConsentChanged)
+        // call notifyConsentChanged from a closure to avoid retain cycles.
+        self.provider.setChangeCallback( { [weak self] in
+            self?.notifyConsentChanged()
+        })
     }
     
     public func configure(analytics: Analytics) {


### PR DESCRIPTION
When using the Consent plugin, we have noticed some retain cycles issues  :

- Use a weak reference for analytics instance in `ConsentBlocker` and `ConsentManager` to avoid retain cycles.

- There is a retain cycle between ConsentManager and Provider.  

<img width="484" height="155" alt="Capture d’écran 2025-07-22 à 16 30 01" src="https://github.com/user-attachments/assets/2e561347-7665-4eee-9c7b-48a677b4f73c" />

<img width="327" height="137" alt="Capture d’écran 2025-07-22 à 16 30 10" src="https://github.com/user-attachments/assets/be62becc-1f82-4e97-adcb-c2841a1e52d3" />

 

