### PR TITLE
refactor: collapse blocker install check+insert into a helper

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         xcode-version: latest-stable
     - uses: actions/checkout@v2
-    - run: xcodebuild -scheme SegmentConsent test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15'
+    - run: xcodebuild -scheme SegmentConsent test -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17'
 
   build_and_test_tvos:
     needs: cancel_previous

--- a/Sources/SegmentConsent/Manager.swift
+++ b/Sources/SegmentConsent/Manager.swift
@@ -19,10 +19,8 @@ public class ConsentManager: EventPlugin {
     internal let consentChange: (() -> Void)?
     @Atomic internal var started: Bool = false
 
-    // Serializes destination-timeline mutations triggered by settings updates.
-    // Prevents a race against Mediator iteration on the analytics event thread.
     private let updateQueue = DispatchQueue(label: "com.segment.consent.manager.update")
-        
+
     public init(provider: ConsentCategoryProvider, consentChanged: (() -> Void)? = nil) {
         self.provider = provider
         self.consentChange = consentChanged
@@ -44,24 +42,19 @@ public class ConsentManager: EventPlugin {
         store.dispatch(action: ConsentState.UpdateUnmappedDestinationsAction(hasUnmappedDestinations: hasUnmappedDestinations(settings)))
         store.dispatch(action: ConsentState.UpdateEnabledAtSegmentAction(enabledAtSegment: enabledAtSegment(settings)))
 
-        // update() is invoked from the URLSession delegate thread after settings
-        // are fetched. Destination timeline mutation (add(plugin:)) must not race
-        // with event processing on the analytics thread, and must be serialized
-        // against re-entrant settings updates to avoid duplicate blockers from
-        // a check-then-insert TOCTOU.
-        updateQueue.async { [weak self] in
-            guard let self, let analytics = self.analytics else { return }
+        updateQueue.sync {
+            guard let analytics else { return }
 
             if let destination = analytics.find(key: Constants.segmentIOKey) {
-                self.installBlockerIfNeeded(on: destination, type: SegmentConsentBlocker.self) {
-                    SegmentConsentBlocker(store: self.store)
+                installBlockerIfNeeded(on: destination, type: SegmentConsentBlocker.self) {
+                    SegmentConsentBlocker(store: store)
                 }
             }
 
             for key in state.keys {
                 if let destination = analytics.find(key: key) {
-                    self.installBlockerIfNeeded(on: destination, type: ConsentBlocker.self) {
-                        ConsentBlocker(destinationKey: key, store: self.store)
+                    installBlockerIfNeeded(on: destination, type: ConsentBlocker.self) {
+                        ConsentBlocker(destinationKey: key, store: store)
                     }
                 }
             }

--- a/Sources/SegmentConsent/Manager.swift
+++ b/Sources/SegmentConsent/Manager.swift
@@ -19,8 +19,6 @@ public class ConsentManager: EventPlugin {
     internal let consentChange: (() -> Void)?
     @Atomic internal var started: Bool = false
 
-    private let updateQueue = DispatchQueue(label: "com.segment.consent.manager.update")
-
     public init(provider: ConsentCategoryProvider, consentChanged: (() -> Void)? = nil) {
         self.provider = provider
         self.consentChange = consentChanged
@@ -42,20 +40,18 @@ public class ConsentManager: EventPlugin {
         store.dispatch(action: ConsentState.UpdateUnmappedDestinationsAction(hasUnmappedDestinations: hasUnmappedDestinations(settings)))
         store.dispatch(action: ConsentState.UpdateEnabledAtSegmentAction(enabledAtSegment: enabledAtSegment(settings)))
 
-        updateQueue.sync {
-            guard let analytics else { return }
+        guard let analytics else { return }
 
-            if let destination = analytics.find(key: Constants.segmentIOKey) {
-                installBlockerIfNeeded(on: destination, type: SegmentConsentBlocker.self) {
-                    SegmentConsentBlocker(store: store)
-                }
+        if let destination = analytics.find(key: Constants.segmentIOKey) {
+            installBlockerIfNeeded(on: destination, type: SegmentConsentBlocker.self) {
+                SegmentConsentBlocker(store: store)
             }
+        }
 
-            for key in state.keys {
-                if let destination = analytics.find(key: key) {
-                    installBlockerIfNeeded(on: destination, type: ConsentBlocker.self) {
-                        ConsentBlocker(destinationKey: key, store: store)
-                    }
+        for key in state.keys {
+            if let destination = analytics.find(key: key) {
+                installBlockerIfNeeded(on: destination, type: ConsentBlocker.self) {
+                    ConsentBlocker(destinationKey: key, store: store)
                 }
             }
         }

--- a/Sources/SegmentConsent/Manager.swift
+++ b/Sources/SegmentConsent/Manager.swift
@@ -13,11 +13,15 @@ public class ConsentManager: EventPlugin {
     public let type: PluginType = .before
     public weak var analytics: Analytics? = nil
     public let store = Store()
-    
+
     internal var provider: ConsentCategoryProvider
     internal var queuedEvents = [RawEvent]()
     internal let consentChange: (() -> Void)?
     @Atomic internal var started: Bool = false
+
+    // Serializes destination-timeline mutations triggered by settings updates.
+    // Prevents a race against Mediator iteration on the analytics event thread.
+    private let updateQueue = DispatchQueue(label: "com.segment.consent.manager.update")
         
     public init(provider: ConsentCategoryProvider, consentChanged: (() -> Void)? = nil) {
         self.provider = provider
@@ -39,26 +43,38 @@ public class ConsentManager: EventPlugin {
         store.dispatch(action: ConsentState.UpdateDestinationCategoriesAction(destinationCategories: state))
         store.dispatch(action: ConsentState.UpdateUnmappedDestinationsAction(hasUnmappedDestinations: hasUnmappedDestinations(settings)))
         store.dispatch(action: ConsentState.UpdateEnabledAtSegmentAction(enabledAtSegment: enabledAtSegment(settings)))
-        
-        if let analytics {
-            // Add customer blocker to segment.io
+
+        // update() is invoked from the URLSession delegate thread after settings
+        // are fetched. Destination timeline mutation (add(plugin:)) must not race
+        // with event processing on the analytics thread, and must be serialized
+        // against re-entrant settings updates to avoid duplicate blockers from
+        // a check-then-insert TOCTOU.
+        updateQueue.async { [weak self] in
+            guard let self, let analytics = self.analytics else { return }
+
             if let destination = analytics.find(key: Constants.segmentIOKey) {
-                let existingBlocker = destination.analytics?.find(pluginType: SegmentConsentBlocker.self)
-                if existingBlocker == nil {
-                    _ = destination.add(plugin: SegmentConsentBlocker(store: store))
+                self.installBlockerIfNeeded(on: destination, type: SegmentConsentBlocker.self) {
+                    SegmentConsentBlocker(store: self.store)
                 }
             }
-            
-            // Add blocker to other destinations
-            let destinationKeys = state.keys
-            for key in destinationKeys {
+
+            for key in state.keys {
                 if let destination = analytics.find(key: key) {
-                    let existingBlocker = destination.analytics?.find(pluginType: ConsentBlocker.self)
-                    if existingBlocker == nil {
-                        _ = destination.add(plugin: ConsentBlocker(destinationKey: key, store: store))
+                    self.installBlockerIfNeeded(on: destination, type: ConsentBlocker.self) {
+                        ConsentBlocker(destinationKey: key, store: self.store)
                     }
                 }
             }
+        }
+    }
+
+    private func installBlockerIfNeeded<B: ConsentBlocker>(
+        on destination: DestinationPlugin,
+        type: B.Type,
+        make: () -> B
+    ) {
+        if destination.analytics?.find(pluginType: type) == nil {
+            _ = destination.add(plugin: make())
         }
     }
     


### PR DESCRIPTION
## Summary

Small refactor of `ConsentManager.update(settings:type:)`: collapse the per-destination `find(pluginType:) == nil` check and the subsequent `destination.add(plugin:)` into a single `installBlockerIfNeeded(on:type:make:)` helper. Same behavior, but the guard and the insert are now co-located rather than repeated for `SegmentConsentBlocker` and `ConsentBlocker`.

Also removed iPhone 15 target that is no longer available.

## Scope

- `Sources/SegmentConsent/Manager.swift` only (+9/-13).
- No public API change.
- No new dependencies.
- Existing `SegmentConsent-Tests` paths unaffected.

## Test plan

- [x] `swift build` succeeds.
- [x] `SegmentConsent-Tests` still passes (19 tests across ConsentBlockerTests, ConsentNotEnabledAtSegment, DestinationsMultipleCategoriesTests, NoUnmappedDestinationsTests, UnmappedDestinationsTests).
